### PR TITLE
Fix RemovedInPytest4Warning with dbdiff marks

### DIFF
--- a/dbdiff/plugin.py
+++ b/dbdiff/plugin.py
@@ -14,7 +14,7 @@ from .sequence import sequence_reset
 
 @pytest.fixture(autouse=True)
 def _dbdiff_marker(request):
-    marker = request.keywords.get('dbdiff', None)
+    marker = request.node.get_closest_marker('dbdiff')
     if not marker:
         return
 


### PR DESCRIPTION
Fixes https://github.com/yourlabs/django-dbdiff/issues/14.
Closes https://github.com/yourlabs/django-dbdiff/pull/13.